### PR TITLE
Typo

### DIFF
--- a/manifests/resource/repository/rubygems/proxy.pp
+++ b/manifests/resource/repository/rubygems/proxy.pp
@@ -51,22 +51,22 @@ define nexus::resource::repository::rubygems::proxy (
     format     => 'rubygems',
     type       => 'proxy',
     attributes => {
-      'online'        => $online,
-      'storage'       => {
+      'online'          => $online,
+      'storage'         => {
         'blobStoreName'               => $storage_blob_store_name,
         'strictContentTypeValidation' => $storage_strict_content_type_validation,
       },
-      'cleanup'       => undef,
-      'proxy'         => {
+      'cleanup'         => undef,
+      'proxy'           => {
         'remoteUrl'      => $proxy_remote_url,
         'contentMaxAge'  => $proxy_content_max_age,
         'metadataMaxAge' => $proxy_metadata_max_age,
       },
-      'negativeCache' => {
+      'negativeCache'   => {
         'enabled'    => $negative_cache_enabled,
         'timeToLive' => $negative_cache_time_to_live,
       },
-      'httpClient'    => {
+      'httpClient'      => {
         'blocked'        => $http_client_blocked,
         'autoBlock'      => $http_client_auto_block,
         'connection'     => {
@@ -79,7 +79,7 @@ define nexus::resource::repository::rubygems::proxy (
         },
         'authentication' => undef,
       },
-      'routingRule'   => undef,
+      'routingRuleName' => undef,
     },
   }
 }


### PR DESCRIPTION
I keep having this message 

```
Notice: /Stage[main]/Profile::Nexus/Nexus::Resource::Repository::Rubygems::Proxy[rubygems]/Nexus_repository[rubygems]/attributes: attributes changed {

  'online' => true,
  'storage' => {
    'blobStoreName' => 'rubygems',
    'strictContentTypeValidation' => true
  },
  'cleanup' => undef,
  'proxy' => {
    'remoteUrl' => 'https://rubygems.org/',
    'contentMaxAge' => 1440,
    'metadataMaxAge' => 1440
  },
  'negativeCache' => {
    'enabled' => true,
    'timeToLive' => 1440
  },
  'httpClient' => {
    'blocked' => false,
    'autoBlock' => true,
    'connection' => {
      'retries' => undef,
      'userAgentSuffix' => undef,
      'timeout' => undef,
      'enableCircularRedirects' => false,
      'enableCookies' => false,
      'useTrustStore' => false
    },
    'authentication' => undef
  },
  'routingRuleName' => undef
} to {
  'online' => true,
  'storage' => {
    'blobStoreName' => 'rubygems',
    'strictContentTypeValidation' => true
  },
  'cleanup' => undef,
  'proxy' => {
    'remoteUrl' => 'https://rubygems.org/',
    'contentMaxAge' => 1440,
    'metadataMaxAge' => 1440
  },
  'negativeCache' => {
    'enabled' => true,
    'timeToLive' => 1440
  },
  'httpClient' => {
    'blocked' => false,
    'autoBlock' => true,
    'connection' => {
      'retries' => undef,
      'userAgentSuffix' => undef,
      'timeout' => undef,
      'enableCircularRedirects' => false,
      'enableCookies' => false,
      'useTrustStore' => false
    },
    'authentication' => undef
  },
  'routingRule' => undef
} (corrective)
```

routingRule vs routingRuleName

According to service/rest/swagger.json :
```
    "RubyGemsProxyRepositoryApiRequest" : {
      "type" : "object",
      "required" : [ "httpClient", "name", "negativeCache", "online", "proxy", "storage" ],
      "properties" : {
        "name" : {
          "type" : "string",
          "example" : "internal",
          "description" : "A unique identifier for this repository",
          "pattern" : "^[a-zA-Z0-9\\-]{1}[a-zA-Z0-9_\\-\\.]*$"
        },
        "online" : {
          "type" : "boolean",
          "example" : true,
          "description" : "Whether this repository accepts incoming requests"
        },
        "storage" : {
          "$ref" : "#/definitions/StorageAttributes"
        },
        "cleanup" : {
          "$ref" : "#/definitions/CleanupPolicyAttributes"
        },
        "proxy" : {
          "$ref" : "#/definitions/ProxyAttributes"
        },
        "negativeCache" : {
          "$ref" : "#/definitions/NegativeCacheAttributes"
        },
        "httpClient" : {
          "$ref" : "#/definitions/HttpClientAttributes"
        },
        "routingRule" : {
          "type" : "string"
        },
        "replication" : {
          "$ref" : "#/definitions/ReplicationAttributes"
        }
      }
    },
```

Might be a bug ...
