### PR TITLE
Fix 'notice'

### DIFF
--- a/manifests/config/email.pp
+++ b/manifests/config/email.pp
@@ -32,7 +32,7 @@ class nexus::config::email (
   Boolean $enabled = false,
   Stdlib::Host $host = 'localhost',
   Stdlib::Port $port = 25,
-  Optional[String[1]] $username = undef,
+  String $username = '', # lint:ignore:params_empty_string_assignment
   Optional[String[1]] $password = undef,
   String[1] $from_address = 'nexus@example.org',
   Optional[String[1]] $subject_prefix = undef,

--- a/spec/classes/config/email_spec.rb
+++ b/spec/classes/config/email_spec.rb
@@ -10,7 +10,7 @@ describe 'nexus::config::email' do
       'enabled' => false,
       'host' => 'localhost',
       'port' => 25,
-      'username' => nil,
+      'username' => '',
       'password' => nil,
       'fromAddress' => 'nexus@example.org',
       'subjectPrefix' => nil,


### PR DESCRIPTION
HI @TuningYourCode ,

I wanted to bring to your attention a regression introduced by this pull request : https://github.com/puppets-epic-show-theatre/puppet-nexus/pull/52

```
Notice: /Stage[main]/Nexus::Config::Email/Nexus_setting[email]/attributes: attributes changed {
  'enabled' => false,
  'host' => 'localhost',
  'port' => 25,
  'username' => '',                                                                    -> Here
  'password' => undef,
  'fromAddress' => 'nexus@example.org',
  'subjectPrefix' => undef,
  'startTlsEnabled' => false,
  'startTlsRequired' => false,
  'sslOnConnectEnabled' => false,
  'sslServerIdentityCheckEnabled' => false,
  'nexusTrustStoreEnabled' => false
} to {
  'enabled' => false,
  'host' => 'localhost',
  'port' => 25,
  'username' => undef,                                                                    -> Here
  'password' => undef,
  'fromAddress' => 'nexus@example.org',
  'subjectPrefix' => undef,
  'startTlsEnabled' => false,
  'startTlsRequired' => false,
  'sslOnConnectEnabled' => false,
  'sslServerIdentityCheckEnabled' => false,
  'nexusTrustStoreEnabled' => false
} (corrective)
```

I initially attempted to adhere to the best practice outlined here: https://github.com/voxpupuli/puppet-lint-params_empty_string-check.
However, I realize that Nexus expects an empty string...

My apologies for the oversight.

