### PR TITLE
Handle Nexus versions >= 3.67.0-03

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,8 @@
 #
 # @param version
 #   The version to download, install and manage.
+# @param java_runtime
+#   The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03.
 # @param download_folder
 #   Destination folder of the downloaded archive.
 # @param download_site
@@ -50,6 +52,7 @@
 #
 class nexus (
   Optional[Pattern[/3.\d+.\d+-\d+/]] $version,
+  Optional[Enum['java8', 'java11']] $java_runtime,
   Stdlib::Absolutepath $download_folder,
   Stdlib::HTTPUrl $download_site,
   Optional[Stdlib::HTTPUrl] $download_proxy,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,16 +3,10 @@
 #
 # @see https://help.sonatype.com/repomanager3/product-information/download/download-archives---repository-manager-3
 #
-# @param version
-#   The version to download, install and manage.
-# @param java_runtime
-#   The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03.
 # @param download_folder
 #   Destination folder of the downloaded archive.
 # @param download_site
 #   Download uri which will be appended with filename of the archive to download.
-# @param download_proxy
-#   Proxyserver address which will be used to download the archive file.
 # @param install_root
 #   The root filesystem path where the downloaded archive will be extracted to.
 # @param work_dir
@@ -40,10 +34,16 @@
 # @param package_type
 #   Select 'src' for Source download & install. 'pkg' will fetch te specified package and version
 #   from repos you must provide.
-# @param package_name
-#   The name of the package to install. Default 'nexus'
 # @param package_ensure
 #   The version to install. See https://puppet.com/docs/puppet/7/types/package.html#package-attribute-ensure
+# @param download_proxy
+#   Proxyserver address which will be used to download the archive file.
+# @param version
+#   The version to download, install and manage.
+# @param java_runtime
+#   The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03.
+# @param package_name
+#   The name of the package to install. Default 'nexus'
 #
 # @example
 #   class{ 'nexus':
@@ -51,11 +51,8 @@
 #   }
 #
 class nexus (
-  Optional[Pattern[/3.\d+.\d+-\d+/]] $version,
-  Optional[Enum['java8', 'java11']] $java_runtime,
   Stdlib::Absolutepath $download_folder,
   Stdlib::HTTPUrl $download_site,
-  Optional[Stdlib::HTTPUrl] $download_proxy,
   Stdlib::Absolutepath $install_root,
   Stdlib::Absolutepath $work_dir,
   String[1] $user,
@@ -69,8 +66,11 @@ class nexus (
   Boolean $purge_installations,
   Boolean $purge_default_repositories,
   Enum['src', 'pkg'] $package_type,
-  Optional[String] $package_name,
   String $package_ensure,
+  Optional[Stdlib::HTTPUrl] $download_proxy = undef,
+  Optional[Pattern[/3.\d+.\d+-\d+/]] $version = undef,
+  Optional[Enum['java8', 'java11']] $java_runtime = undef,
+  Optional[String] $package_name = undef,
 ) {
   include stdlib
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -11,7 +11,14 @@ class nexus::package {
       if !$nexus::version {
         fail('nexus::version must be set when using package_type => src')
       }
-      $nexus_archive   = "nexus-${nexus::version}-unix.tar.gz"
+
+      if $nexus::java_runtime {
+        # Relevant only for Nexus versions >= 3.67.0-03
+        $nexus_archive   = "nexus-${nexus::version}-${nexus::java_runtime}-unix.tar.gz"
+      } else {
+        $nexus_archive   = "nexus-${nexus::version}-unix.tar.gz"
+      }
+
       $download_url    = "${nexus::download_site}/${nexus_archive}"
       $dl_file         = "${nexus::download_folder}/${nexus_archive}"
       $install_dir     = "${nexus::install_root}/nexus-${nexus::version}"


### PR DESCRIPTION
Nexus now allows us to choose between Java 8 or Java 11 runtime, which means that the download URL(s) have been changed:

Before:
- https://download.sonatype.com/nexus/3/nexus-3.66.0-02-unix.tar.gz

Now:
- https://download.sonatype.com/nexus/3/nexus-3.67.0-03-java8-unix.tar.gz
- https://download.sonatype.com/nexus/3/nexus-3.67.0-03-java11-unix.tar.gz

Since the tar.gz archive doesn't include the full version name, we simply need to add a new 'java_runtime' variable to choose the correct path URL for downloading files.