### PR TITLE
Handle >= 3.71.0 nexus versions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -174,7 +174,7 @@ Set if this module should manage the work directory of the nexus repository mana
 
 Data type: `Boolean`
 
-Set if this module should manage datastore - ATM only postgresql is supported
+Set if this module should manage datastore - Note that you need a licence for postgresql backend
 
 ##### <a name="-nexus--purge_installations"></a>`purge_installations`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -210,7 +210,7 @@ Default value: `undef`
 
 Data type: `Optional[Enum['java8', 'java11']]`
 
-The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03.
+The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03 and < 3.71.0.
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,6 +14,7 @@
 * [`nexus::config::default_repositories`](#nexus--config--default_repositories): Removes the default repositories for maven and nuget
 * [`nexus::config::device`](#nexus--config--device): Create puppet device config used to connect to the rest api
 * [`nexus::config::email`](#nexus--config--email): Manage the nexus repository manager email settings
+* [`nexus::config::postgresql_datastore`](#nexus--config--postgresql_datastore): Manage the nexus postgresql datastore settings
 * [`nexus::config::properties`](#nexus--config--properties): A short summary of the purpose of this class
 * [`nexus::plugin::composer`](#nexus--plugin--composer): Install the composer repository format plugin
 
@@ -84,6 +85,7 @@ The following parameters are available in the `nexus` class:
 * [`manage_config`](#-nexus--manage_config)
 * [`manage_user`](#-nexus--manage_user)
 * [`manage_work_dir`](#-nexus--manage_work_dir)
+* [`manage_datastore`](#-nexus--manage_datastore)
 * [`purge_installations`](#-nexus--purge_installations)
 * [`purge_default_repositories`](#-nexus--purge_default_repositories)
 * [`package_type`](#-nexus--package_type)
@@ -92,6 +94,9 @@ The following parameters are available in the `nexus` class:
 * [`version`](#-nexus--version)
 * [`java_runtime`](#-nexus--java_runtime)
 * [`package_name`](#-nexus--package_name)
+* [`postgresql_username`](#-nexus--postgresql_username)
+* [`postgresql_password`](#-nexus--postgresql_password)
+* [`postgresql_jdbcurl`](#-nexus--postgresql_jdbcurl)
 
 ##### <a name="-nexus--download_folder"></a>`download_folder`
 
@@ -165,6 +170,12 @@ Data type: `Boolean`
 
 Set if this module should manage the work directory of the nexus repository manager.
 
+##### <a name="-nexus--manage_datastore"></a>`manage_datastore`
+
+Data type: `Boolean`
+
+Set if this module should manage datastore - ATM only postgresql is supported
+
 ##### <a name="-nexus--purge_installations"></a>`purge_installations`
 
 Data type: `Boolean`
@@ -219,6 +230,31 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 The name of the package to install. Default 'nexus'
+
+Default value: `undef`
+
+##### <a name="-nexus--postgresql_username"></a>`postgresql_username`
+
+Data type: `Optional[String[1]]`
+
+Postgresql Username - Only available in Sonatype Nexus Repository Pro
+
+Default value: `undef`
+
+##### <a name="-nexus--postgresql_password"></a>`postgresql_password`
+
+Data type: `Optional[String[1]]`
+
+Postgresql Password - Only available in Sonatype Nexus Repository Pro
+
+Default value: `undef`
+
+##### <a name="-nexus--postgresql_jdbcurl"></a>`postgresql_jdbcurl`
+
+Data type: `Optional[String[1]]`
+
+Postgresql jdbcUrl. Formatted as jdbc\:postgresql\://<database-host>\:<database-port>/nexus
+Only available in Sonatype Nexus Repository Pro
 
 Default value: `undef`
 
@@ -477,6 +513,10 @@ Data type: `Boolean`
 Use certificates stored in the Nexus truststore to connect to external systems.
 
 Default value: `false`
+
+### <a name="nexus--config--postgresql_datastore"></a>`nexus::config::postgresql_datastore`
+
+Only available in Sonatype Nexus Repository Pro
 
 ### <a name="nexus--config--properties"></a>`nexus::config::properties`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,6 +15,7 @@ nexus::purge_installations: true
 nexus::purge_default_repositories: false
 nexus::user: nexus
 nexus::work_dir: "%{lookup('nexus::install_root')}/sonatype-work/nexus3"
-nexus::package_type: 'src'
-nexus::package_name: 'nexus'
-nexus::package_ensure: 'installed'
+nexus::package_type: src
+nexus::package_name: nexus
+nexus::package_ensure: installed
+nexus::datastore_enabled: false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -18,4 +18,4 @@ nexus::work_dir: "%{lookup('nexus::install_root')}/sonatype-work/nexus3"
 nexus::package_type: src
 nexus::package_name: nexus
 nexus::package_ensure: installed
-nexus::datastore_enabled: false
+nexus::manage_datastore: false

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,10 @@ class nexus::config {
 
   contain nexus::config::properties
 
+  if $nexus::manage_datastore and $nexus::postgresql_username and $nexus::postgresql_password and $nexus::postgresql_jdbcurl {
+    contain nexus::config::postgresql_datastore
+  }
+
   if $nexus::manage_api_resources {
     contain nexus::config::admin
     contain nexus::config::device

--- a/manifests/config/postgresql_datastore.pp
+++ b/manifests/config/postgresql_datastore.pp
@@ -1,9 +1,7 @@
-# @summary A short summary of the purpose of this class
+# @summary Manage the nexus postgresql datastore settings
 #
-# A description of what this class does
+# Only available in Sonatype Nexus Repository Pro
 #
-# @example
-#   include nexus::config::postgresql_datastore
 class nexus::config::postgresql_datastore {
   assert_private()
 

--- a/manifests/config/postgresql_datastore.pp
+++ b/manifests/config/postgresql_datastore.pp
@@ -1,0 +1,35 @@
+# @summary A short summary of the purpose of this class
+#
+# A description of what this class does
+#
+# @example
+#   include nexus::config::postgresql_datastore
+class nexus::config::postgresql_datastore {
+  assert_private()
+
+  $nexus_store_properties_file = "${nexus::install_root}/nexus-${nexus::version}/etc/fabric/nexus-store.properties"
+
+  # Nexus >=3.x do no necesarily have a properties file in place to
+  # modify. Make sure that there is at least a minmal file there
+  file { $nexus_store_properties_file:
+    ensure => file,
+  }
+
+  file_line { 'nexus-postgresql-username':
+    path  => $nexus_store_properties_file,
+    match => '^username=',
+    line  => "username=${nexus::postgresql_username}",
+  }
+
+  file_line { 'nexus-postgresql-password':
+    path  => $nexus_store_properties_file,
+    match => '^password=',
+    line  => "password=${nexus::postgresql_password}",
+  }
+
+  file_line { 'nexus-postgresql-jdbcurl':
+    path  => $nexus_store_properties_file,
+    match => '^jdbcUrl=',
+    line  => "jdbcUrl=${nexus::postgresql_jdbcurl}",
+  }
+}

--- a/manifests/config/properties.pp
+++ b/manifests/config/properties.pp
@@ -34,4 +34,19 @@ class nexus::config::properties {
     match => '^nexus-work=',
     line  => "nexus-work=${nexus::work_dir}",
   }
+
+  if $nexus::manage_datastore {
+    file_line { 'nexus-datastore-enabled':
+      path  => $nexus_properties_file,
+      match => '^nexus.datastore.enabled',
+      line  => "nexus.datastore.enabled=${nexus::manage_datastore}",
+    }
+  } else {
+    file_line { 'nexus-datastore-enabled':
+      ensure            => absent,
+      path              => $nexus_properties_file,
+      match             => '^nexus.datastore.enabled=',
+      match_for_absence => true,
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,11 +47,12 @@
 # @param package_name
 #   The name of the package to install. Default 'nexus'
 # @param postgresql_username
-#   Postgresql Username
+#   Postgresql Username - Only available in Sonatype Nexus Repository Pro
 # @param postgresql_password
-#   Postgresql Password
+#   Postgresql Password - Only available in Sonatype Nexus Repository Pro
 # @param postgresql_jdbcurl
 #   Postgresql jdbcUrl. Formatted as jdbc\:postgresql\://<database-host>\:<database-port>/nexus
+#   Only available in Sonatype Nexus Repository Pro
 #
 # @example
 #   class{ 'nexus':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,8 @@
 #   Set if this module should manage the creation of the operation system user.
 # @param manage_work_dir
 #   Set if this module should manage the work directory of the nexus repository manager.
+# @param manage_datastore
+#   Set if this module should manage datastore - ATM only postgresql is supported
 # @param purge_installations
 #   Set this option if you want old installations of nexus repository manager to get automatically deleted.
 # @param purge_default_repositories
@@ -44,6 +46,12 @@
 #   The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03 and < 3.71.0.
 # @param package_name
 #   The name of the package to install. Default 'nexus'
+# @param postgresql_username
+#   Postgresql Username
+# @param postgresql_password
+#   Postgresql Password
+# @param postgresql_jdbcurl
+#   Postgresql jdbcUrl. Formatted as jdbc\:postgresql\://<database-host>\:<database-port>/nexus
 #
 # @example
 #   class{ 'nexus':
@@ -63,6 +71,7 @@ class nexus (
   Boolean $manage_config,
   Boolean $manage_user,
   Boolean $manage_work_dir,
+  Boolean $manage_datastore,
   Boolean $purge_installations,
   Boolean $purge_default_repositories,
   Enum['src', 'pkg'] $package_type,
@@ -71,6 +80,9 @@ class nexus (
   Optional[Pattern[/3.\d+.\d+-\d+/]] $version = undef,
   Optional[Enum['java8', 'java11']] $java_runtime = undef,
   Optional[String] $package_name = undef,
+  Optional[String[1]] $postgresql_username = undef,
+  Optional[String[1]] $postgresql_password = undef,
+  Optional[String[1]] $postgresql_jdbcurl = undef,
 ) {
   include stdlib
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@
 # @param version
 #   The version to download, install and manage.
 # @param java_runtime
-#   The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03.
+#   The Java runtime to be utilized. Relevant only for Nexus versions >= 3.67.0-03 and < 3.71.0.
 # @param package_name
 #   The name of the package to install. Default 'nexus'
 #
@@ -74,8 +74,8 @@ class nexus (
 ) {
   include stdlib
 
-  if ($version and versioncmp($version, '3.67.0-03') >= 0 and ! $java_runtime) {
-    fail('You need to define the $java_runtime parameter.')
+  if ($version and versioncmp($version, '3.67.0-03') >= 0 and versioncmp($version, '3.71.0') < 0 and ! $java_runtime) {
+    fail('You need to define the $java_runtime parameter for nexus version >= 3.67.0-03 and < 3.71.0')
   }
 
   contain nexus::user

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@
 # @param manage_work_dir
 #   Set if this module should manage the work directory of the nexus repository manager.
 # @param manage_datastore
-#   Set if this module should manage datastore - ATM only postgresql is supported
+#   Set if this module should manage datastore - Note that you need a licence for postgresql backend
 # @param purge_installations
 #   Set this option if you want old installations of nexus repository manager to get automatically deleted.
 # @param purge_default_repositories

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -13,7 +13,7 @@ class nexus::package {
       }
 
       if $nexus::java_runtime {
-        # Relevant only for Nexus versions >= 3.67.0-03
+        # Relevant only for Nexus versions >= 3.67.0-03 and < 3.71.0
         $nexus_archive   = "nexus-${nexus::version}-${nexus::java_runtime}-unix.tar.gz"
       } else {
         $nexus_archive   = "nexus-${nexus::version}-unix.tar.gz"


### PR DESCRIPTION
Nexus Repository 3.71.0 includes multiple breaking changes.
Version 3.71.0 and beyond do not support OrientDB, Java 8, or Java 11

See https://github.com/puppets-epic-show-theatre/puppet-nexus/issues/67