### PR TITLE
Support v3.80.0 download url

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -13,15 +13,15 @@ class nexus::package {
       }
 
       if $nexus::java_runtime {
-        # Relevant only for Nexus versions >= 3.67.0-03 and < 3.71.0
         $nexus_archive = "nexus-${nexus::version}-${nexus::java_runtime}-unix.tar.gz"
+      } elsif versioncmp($nexus::version, '3.80.0') >= 0 {
+        $arch = regsubst($facts['os']['hardware'], '^aarch64$', 'aarch_64')
+        $nexus_archive = "nexus-${nexus::version}-linux-${arch}.tar.gz"
+      } elsif versioncmp($nexus::version, '3.78.0') >= 0 {
+        $hardware      = regsubst($facts['os']['hardware'], '_','-')
+        $nexus_archive = "nexus-unix-${hardware}-${nexus::version}.tar.gz"
       } else {
-        if (versioncmp($nexus::version, '3.78.0') >= 0) {
-          $hardware      = regsubst($facts['os']['hardware'], '_','-')
-          $nexus_archive = "nexus-unix-${hardware}-${nexus::version}.tar.gz"
-        } else {
-          $nexus_archive = "nexus-${nexus::version}-unix.tar.gz"
-        }
+        $nexus_archive = "nexus-${nexus::version}-unix.tar.gz"
       }
 
       $download_url = "${nexus::download_site}/${nexus_archive}"


### PR DESCRIPTION
Sonatype has changed the format of the download URL. This PR supports the new format. 